### PR TITLE
Make route authentication configurable at startup

### DIFF
--- a/application/src/main/scala/api/Auth.scala
+++ b/application/src/main/scala/api/Auth.scala
@@ -1,0 +1,19 @@
+package com.jisantuc.configableauth.api
+
+import com.jisantuc.configableauth.api.commands.AuthConfig
+import com.jisantuc.configableauth.api.endpoints.TokenHeader
+import com.jisantuc.configableauth.datamodel.Domain
+
+import cats.implicits._
+import cats.effect.Sync
+import eu.timepit.refined.auto._
+
+class Auth[F[_]: Sync](authConfig: AuthConfig) {
+
+  def authenticateRoute(domain: Domain)(tokenHeaderO: Option[TokenHeader]): F[Either[String, Unit]] =
+    (authConfig.authedDomains.contains(domain), tokenHeaderO) match {
+      case (true, Some(_)) => Sync[F].pure(Either.right(()))
+      case (false, _)      => Sync[F].pure(Either.right(()))
+      case _               => Sync[F].pure(Either.left("need a token for this route"))
+    }
+}

--- a/application/src/main/scala/api/commands/AuthConfig.scala
+++ b/application/src/main/scala/api/commands/AuthConfig.scala
@@ -1,0 +1,7 @@
+package com.jisantuc.configableauth.api.commands
+
+import com.jisantuc.configableauth.datamodel.Domain
+
+final case class AuthConfig(
+    authedDomains: Set[Domain]
+)

--- a/application/src/main/scala/api/commands/AuthOptions.scala
+++ b/application/src/main/scala/api/commands/AuthOptions.scala
@@ -1,0 +1,16 @@
+package com.jisantuc.configableauth.api.commands
+
+import com.monovore.decline.Opts
+import com.jisantuc.configableauth.datamodel.Domain
+
+trait AuthOptions {
+
+  private val authedDomains =
+    Opts
+      .options[Domain]("authed-domain", help = "Which sorts of actions to require authentication for")
+      .orEmpty
+
+  val authConfig: Opts[AuthConfig] = authedDomains map { domains =>
+    AuthConfig(domains.toSet)
+  }
+}

--- a/application/src/main/scala/api/commands/AuthOptions.scala
+++ b/application/src/main/scala/api/commands/AuthOptions.scala
@@ -6,9 +6,21 @@ import com.jisantuc.configableauth.datamodel.Domain
 trait AuthOptions {
 
   private val authedDomains =
-    Opts
-      .options[Domain]("authed-domain", help = "Which sorts of actions to require authentication for")
-      .orEmpty
+    (Opts
+      .options[Domain](
+        "authed-domain",
+        help =
+          "Which sorts of actions to require authentication for. Excludes --auth-all as a valid option if provided."
+      )
+      .orEmpty)
+      .orElse(
+        Opts
+          .flag("auth-all", help = "Authenticate all routes. Excludes --authed-domain as valid options if provided.")
+          .orFalse map {
+          case true => List(Domain.Read, Domain.Destructive, Domain.Creative)
+          case _    => Nil
+        }
+      )
 
   val authConfig: Opts[AuthConfig] = authedDomains map { domains =>
     AuthConfig(domains.toSet)

--- a/application/src/main/scala/api/commands/Commands.scala
+++ b/application/src/main/scala/api/commands/Commands.scala
@@ -9,7 +9,7 @@ object Commands {
 
   final case class RunMigrations(databaseConfig: DatabaseConfig)
 
-  final case class RunServer(apiConfig: ApiConfig, dbConfig: DatabaseConfig)
+  final case class RunServer(apiConfig: ApiConfig, authConfig: AuthConfig, dbConfig: DatabaseConfig)
 
   private def runMigrationsOpts(implicit cs: ContextShift[IO]): Opts[RunMigrations] =
     Opts.subcommand("migrate", "Runs migrations against database") {
@@ -18,7 +18,7 @@ object Commands {
 
   private def runServerOpts(implicit cs: ContextShift[IO]): Opts[RunServer] =
     Opts.subcommand("serve", "Runs web service") {
-      (Options.apiConfig, Options.databaseConfig) mapN RunServer
+      (Options.apiConfig, Options.authConfig, Options.databaseConfig) mapN RunServer
     }
 
   def runMigrations(dbConfig: DatabaseConfig): IO[ExitCode] = IO {

--- a/application/src/main/scala/api/commands/Options.scala
+++ b/application/src/main/scala/api/commands/Options.scala
@@ -2,7 +2,7 @@ package com.jisantuc.configableauth.api.commands
 
 import com.monovore.decline.Opts
 
-object Options extends DatabaseOptions with ApiOptions {
+object Options extends DatabaseOptions with ApiOptions with AuthOptions {
 
   val catalogRoot: Opts[String] = Opts
     .option[String]("catalog-root", "Root of STAC catalog to import")

--- a/application/src/main/scala/api/endpoints/UserEndpoints.scala
+++ b/application/src/main/scala/api/endpoints/UserEndpoints.scala
@@ -10,35 +10,40 @@ object UserEndpoints {
 
   val base = endpoint.in("users").in(header[Option[TokenHeader]]("Authorization"))
 
-  val listUsers: Endpoint[Option[TokenHeader], Unit, List[User], Nothing] =
+  val listUsers: Endpoint[Option[TokenHeader], String, List[User], Nothing] =
     base.get
       .out(jsonBody[List[User]])
+      .errorOut(stringBody)
       .description("List Users")
       .name("User List View")
 
-  val getUser: Endpoint[(Option[TokenHeader], UUID), Unit, User, Nothing] =
+  val getUser: Endpoint[(Option[TokenHeader], UUID), String, User, Nothing] =
     base.get
       .in(path[UUID])
       .out(jsonBody[User])
+      .errorOut(stringBody)
       .description("Retrieve a single user")
       .name("search-get")
 
-  val createUser: Endpoint[(Option[TokenHeader], User.Create), Unit, User, Nothing] =
+  val createUser: Endpoint[(Option[TokenHeader], User.Create), String, User, Nothing] =
     base.post
       .in(jsonBody[User.Create])
       .out(jsonBody[User])
+      .errorOut(stringBody)
       .description("Create a User")
       .name("create-user")
 
-  val deleteUser: Endpoint[(Option[TokenHeader], UUID), Unit, Unit, Nothing] =
+  val deleteUser: Endpoint[(Option[TokenHeader], UUID), String, Unit, Nothing] =
     base.delete
       .in(path[UUID])
+      .errorOut(stringBody)
       .description("Delete a user")
 
-  val updateUser: Endpoint[(Option[TokenHeader], User, UUID), Unit, Unit, Nothing] =
+  val updateUser: Endpoint[(Option[TokenHeader], User, UUID), String, Unit, Nothing] =
     base.put
       .in(jsonBody[User])
       .in(path[UUID])
+      .errorOut(stringBody)
       .description("Update a user")
       .name("update-user")
 

--- a/application/src/main/scala/api/services/UserService.scala
+++ b/application/src/main/scala/api/services/UserService.scala
@@ -1,12 +1,12 @@
 package com.jisantuc.configableauth.api.services
 
-import java.util.UUID
+import com.jisantuc.configableauth.api.Auth
 
 import cats.effect._
 import cats.implicits._
-import com.jisantuc.configableauth.api.endpoints.{TokenHeader, UserEndpoints}
+import com.jisantuc.configableauth.api.endpoints.UserEndpoints
 import com.jisantuc.configableauth.database.UserDao
-import com.jisantuc.configableauth.datamodel.User
+import com.jisantuc.configableauth.datamodel.{Domain, User}
 import doobie.util.transactor.Transactor
 import doobie._
 import doobie.implicits._
@@ -15,40 +15,71 @@ import org.http4s.dsl.Http4sDsl
 import sttp.tapir.server.http4s._
 import eu.timepit.refined.auto._
 
-class UsersService[F[_]: Sync](xa: Transactor[F])(
+import java.util.UUID
+
+class UsersService[F[_]: Sync](auth: Auth[F], xa: Transactor[F])(
     implicit contextShift: ContextShift[F]
 ) extends Http4sDsl[F] {
 
-  def listUsers(tokenHeader: Option[TokenHeader]): F[Either[Unit, List[User]]] =
+  def listUsers: F[Either[String, List[User]]] =
     UserDao.query.list.transact(xa).map(Either.right)
 
-  def getUser(tokenHeader: Option[TokenHeader], id: UUID): F[Either[Unit, User]] =
+  def getUser(id: UUID): F[Either[String, User]] =
     UserDao.query.filter(id).selectOption.transact(xa) map {
       case Some(user) => Either.right(user)
-      case _          => Either.left(())
+      case _          => Either.left("not found")
     }
 
-  def createUser(tokenHeader: Option[TokenHeader], user: User.Create): F[Either[Unit, User]] =
+  def createUser(user: User.Create): F[Either[String, User]] =
     UserDao.create(user).transact(xa) map {
       case user: User => Either.right(user)
-      case _          => Either.left(())
+      case _          => Either.left("could not create user")
     }
 
-  def deleteUser(tokenHeader: Option[TokenHeader], id: UUID): F[Either[Unit, Unit]] =
+  def deleteUser(id: UUID): F[Either[String, Unit]] =
     UserDao.query.filter(id).delete.transact(xa) map {
       case 1 => Either.right(())
-      case _ => Either.left(())
+      case _ => Either.left("could not delete user or deleted several :thinking:")
     }
 
-  def updateUser(tokenHeader: Option[TokenHeader], user: User, id: UUID): F[Either[Unit, Unit]] =
+  def updateUser(user: User, id: UUID): F[Either[String, Unit]] =
     UserDao.update(id, user).transact(xa) map {
       case 1 => Either.right(())
-      case _ => Either.left(())
+      case _ => Either.left("could not update user or updated several :thinking:")
     }
 
-  val routes: HttpRoutes[F] = UserEndpoints.listUsers.toRoutes(u => listUsers(u)) <+> UserEndpoints.getUser
-    .toRoutes(Function.tupled(getUser)) <+> UserEndpoints.createUser.toRoutes(
-    Function.tupled(createUser)
-  ) <+> UserEndpoints.deleteUser.toRoutes(Function.tupled(deleteUser)) <+> UserEndpoints.updateUser
-    .toRoutes(Function.tupled(updateUser))
+  val listRoute = UserEndpoints.listUsers
+    .serverLogicPart(auth.authenticateRoute(Domain.Read))
+    .andThen(_ => listUsers)
+    .toRoutes
+
+  val detailRoute = UserEndpoints.getUser
+    .serverLogicPart(auth.authenticateRoute(Domain.Read))
+    .andThen({
+      case ((), userId) => getUser(userId)
+    })
+    .toRoutes
+
+  val createRoute = UserEndpoints.createUser
+    .serverLogicPart(auth.authenticateRoute(Domain.Creative))
+    .andThen({
+      case (_, userCreate) => createUser(userCreate)
+    })
+    .toRoutes
+
+  val deleteRoute = UserEndpoints.deleteUser
+    .serverLogicPart(auth.authenticateRoute(Domain.Destructive))
+    .andThen({
+      case ((), userId) => deleteUser(userId)
+    })
+    .toRoutes
+
+  val updateRoute = UserEndpoints.updateUser
+    .serverLogicPart(auth.authenticateRoute(Domain.Destructive))
+    .andThen({
+      case ((), (update, userId)) => updateUser(update, userId)
+    })
+    .toRoutes
+
+  val routes: HttpRoutes[F] = listRoute <+> detailRoute <+> createRoute <+> deleteRoute <+> updateRoute
 }

--- a/application/src/main/scala/datamodel/Domain.scala
+++ b/application/src/main/scala/datamodel/Domain.scala
@@ -1,0 +1,27 @@
+package com.jisantuc.configableauth.datamodel
+
+import cats.data.{NonEmptyList, ValidatedNel}
+import cats.syntax.validated._
+import com.monovore.decline.Argument
+
+sealed abstract class Domain
+
+object Domain {
+
+  case object Read        extends Domain
+  case object Creative    extends Domain
+  case object Destructive extends Domain
+
+  def fromStringValidated(s: String): ValidatedNel[String, Domain] = s.toLowerCase match {
+    case "read"        => Read.valid
+    case "creative"    => Creative.valid
+    case "destructive" => Destructive.valid
+    case _             => NonEmptyList.of(s"Could not parse domain from: $s").invalid
+  }
+
+  implicit val argumentDomain: Argument[Domain] = new Argument[Domain] {
+    def read(string: String) = fromStringValidated(string)
+
+    def defaultMetavar: String = "authed-domain"
+  }
+}

--- a/sbt
+++ b/sbt
@@ -10,7 +10,7 @@ declare -r sbt_release_version="1.3.2"
 declare -r sbt_unreleased_version="1.3.2"
 
 declare -r latest_213="2.13.1"
-declare -r latest_212="2.12.10"
+declare -r latest_212="2.12.11"
 declare -r latest_211="2.11.12"
 declare -r latest_210="2.10.7"
 declare -r latest_29="2.9.3"


### PR DESCRIPTION
Overview
-----

This PR makes which sorts of routes are authenticated a server startup parameter. It separates routes into "domains", which in this case, because the model is simple, means one of `read`, `creative`, or `destructive`. It then provides two ways to configure which routes are authenticated:

- the `--auth-all` flag puts all routes behind authentication
- the `--authed-domain` option takes a string parameter and can be provided several times

Note that it doesn't _do_ any authentication -- it only uses this configuration to figure out when it would have to.

To see how this works, check out `UserService.scala` and look how `serverLogicPart` is called with a function from `Auth.scala`.

Testing
-----

Start up the server in a few different ways, and make some requests with and without authentication

The requests are:

```bash
$ http :8080/api/users [Authorization:foo]
$ echo '{"email": "foo@bar.com"}' | http :8080/api/users [Authorization:foo]
$ http DELETE :8080/api/users/<user id from previous>[Authorization:foo]
```

The server startup commands are:

```bash
$ bloop run application -- serve --authed-domain read
$ bloop run application -- serve --authed-domain read --authed-domain destructive
$ bloop run application -- serve --authed-domain destructive --authed-domain creative
$ bloop run application -- serve --auth-all
```

It should be obvious which requests should succeed and which shouldn't.